### PR TITLE
Enable `serde` feature on playgrounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ tag-name = "{{version}}"
 
 [package.metadata.docs.rs]
 features = ["serde"]
+
+[package.metadata.playground]
+features = ["serde"]


### PR DESCRIPTION
Playground metadata is explicitly inspired by docs.rs so looks very similar, was implemented at rust-lang/rust-playground#326

Example of usage [at serde](https://github.com/serde-rs/serde/blob/74d06708ddff495161187ea490c4616291216346/serde/Cargo.toml#L26-L27), as well as uuid-rs/uuid#224 for the PR at one of the early adopters / implementers of that system.

@shepmaster looked around a bit, and didn't find any way to test it offline so I assume short of having a bespoke test playground you can only add the metadata and try to remember to check if it works the next time you publish a release?

Fixes #102