### PR TITLE
Specialize `nth_back` (MSRV 1.37)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - 1.36.0  # MSRV
+          - 1.37.0  # MSRV
           - stable
           - beta
           - nightly
@@ -38,7 +38,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
 
       - name: MSRV dependencies
-        if: matrix.rust == '1.36.0'
+        if: matrix.rust == '1.37.0'
         run: |
           cargo generate-lockfile
           cargo update -p serde_json --precise 1.0.99

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "either"
-version = "1.11.0"
+version = "1.12.0"
 authors = ["bluss"]
 edition = "2018"
 rust-version = "1.37"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "either"
 version = "1.11.0"
 authors = ["bluss"]
 edition = "2018"
-rust-version = "1.36"
+rust-version = "1.37"
 
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rayon-rs/either"

--- a/README.rst
+++ b/README.rst
@@ -25,11 +25,17 @@ __ https://docs.rs/either/
 How to use with cargo::
 
     [dependencies]
-    either = "1.11"
+    either = "1.12"
 
 
 Recent Changes
 --------------
+
+- 1.12.0
+
+  - **MSRV**: ``either`` now requires Rust 1.37 or later.
+
+  - Specialize ``nth_back`` for ``Either`` and ``IterEither``, by @cuviper (#106)
 
 - 1.11.0
 

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -141,10 +141,9 @@ where
         for_both!(*self, ref mut inner => inner.next_back())
     }
 
-    // TODO(MSRV): This was stabilized in Rust 1.37
-    // fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-    //     for_both!(*self, ref mut inner => inner.nth_back(n))
-    // }
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        for_both!(*self, ref mut inner => inner.nth_back(n))
+    }
 
     fn rfold<Acc, G>(self, init: Acc, f: G) -> Acc
     where
@@ -279,10 +278,9 @@ where
         Some(map_either!(self.inner, ref mut inner => inner.next_back()?))
     }
 
-    // TODO(MSRV): This was stabilized in Rust 1.37
-    // fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-    //     Some(map_either!(self.inner, ref mut inner => inner.nth_back(n)?))
-    // }
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        Some(map_either!(self.inner, ref mut inner => inner.nth_back(n)?))
+    }
 
     fn rfold<Acc, G>(self, init: Acc, f: G) -> Acc
     where


### PR DESCRIPTION
The commented-out implementations of `nth_back` have had a `TODO(MSRV)` for a while, since that requires Rust 1.37. The main reason we held back on 1.36 was for `itertools`, but they've required 1.43 since `itertools v0.11.0` published 6 months ago. I don't see any other functionality in that range that would be useful to `either` though, so we might as well stick to the minimal bump here.