### PR TITLE
Added either::map_both, either:try_map_both

### DIFF
--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -185,7 +185,7 @@ where
     type Item = Either<L::Item, R::Item>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        Some(map_either!(self.inner, ref mut inner => inner.next()?))
+        Some(map_both!(self.inner, ref mut inner => inner.next()?))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -211,11 +211,11 @@ where
     }
 
     fn last(self) -> Option<Self::Item> {
-        Some(map_either!(self.inner, inner => inner.last()?))
+        Some(map_both!(self.inner, inner => inner.last()?))
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        Some(map_either!(self.inner, ref mut inner => inner.nth(n)?))
+        Some(map_both!(self.inner, ref mut inner => inner.nth(n)?))
     }
 
     fn collect<B>(self) -> B
@@ -275,11 +275,11 @@ where
     R: DoubleEndedIterator,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        Some(map_either!(self.inner, ref mut inner => inner.next_back()?))
+        Some(map_both!(self.inner, ref mut inner => inner.next_back()?))
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        Some(map_either!(self.inner, ref mut inner => inner.nth_back(n)?))
+        Some(map_both!(self.inner, ref mut inner => inner.nth_back(n)?))
     }
 
     fn rfold<Acc, G>(self, init: Acc, f: G) -> Acc

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,41 @@ macro_rules! map_both {
     };
 }
 
+/// Evaluate the provided expression for both [`Either::Left`] and [`Either::Right`],
+/// returning a [Result] where the [`Ok`] variant is an [`Either`] with the results.
+///
+/// This macro is useful in cases where both sides of [`Either`] can be interacted with
+/// in the same way even though the don't share the same type.
+///
+/// `either::map_both!(` *expression* `,` *pattern* `=>` *expression* `)`
+///
+/// Unlike [`map_both!`], this macro returns a [Result] where the [`Ok`] variant is an [`Either`] with the results.
+///
+/// # Example
+///
+/// ```
+/// use either::Either;
+///
+/// fn wrap(owned_or_borrowed: Either<String, &'static str>) -> Result<Either<String, &'static str>, ()> {
+///    either::try_map_both!(owned_or_borrowed, s => Ok(s))
+/// }
+/// ```
+#[macro_export]
+macro_rules! try_map_both {
+    ($value:expr, $pattern:pat => $result:expr) => {
+        match $value {
+            $crate::Either::Left($pattern) => match $result {
+                Ok(ok) => Ok($crate::Either::Left(ok)),
+                Err(err) => Err(err),
+            },
+            $crate::Either::Right($pattern) => match $result {
+                Ok(ok) => Ok($crate::Either::Right(ok)),
+                Err(err) => Err(err),
+            },
+        }
+    };
+}
+
 /// Macro for unwrapping the left side of an [`Either`], which fails early
 /// with the opposite side. Can only be used in functions that return
 /// `Either` because of the early return of `Right` that it provides.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,15 +221,6 @@ macro_rules! try_right {
     };
 }
 
-macro_rules! map_either {
-    ($value:expr, $pattern:pat => $result:expr) => {
-        match $value {
-            Left($pattern) => Left($result),
-            Right($pattern) => Right($result),
-        }
-    };
-}
-
 mod iterator;
 pub use self::iterator::IterEither;
 
@@ -630,7 +621,7 @@ impl<L, R> Either<L, R> {
         L: IntoIterator,
         R: IntoIterator<Item = L::Item>,
     {
-        map_either!(self, inner => inner.into_iter())
+        map_both!(self, inner => inner.into_iter())
     }
 
     /// Borrow the inner value as an iterator.
@@ -653,7 +644,7 @@ impl<L, R> Either<L, R> {
         for<'a> &'a L: IntoIterator,
         for<'a> &'a R: IntoIterator<Item = <&'a L as IntoIterator>::Item>,
     {
-        map_either!(self, inner => inner.into_iter())
+        map_both!(self, inner => inner.into_iter())
     }
 
     /// Mutably borrow the inner value as an iterator.
@@ -684,7 +675,7 @@ impl<L, R> Either<L, R> {
         for<'a> &'a mut L: IntoIterator,
         for<'a> &'a mut R: IntoIterator<Item = <&'a mut L as IntoIterator>::Item>,
     {
-        map_either!(self, inner => inner.into_iter())
+        map_both!(self, inner => inner.into_iter())
     }
 
     /// Converts an `Either` of `Iterator`s to be an `Iterator` of `Either`s
@@ -708,7 +699,7 @@ impl<L, R> Either<L, R> {
         L: IntoIterator,
         R: IntoIterator,
     {
-        IterEither::new(map_either!(self, inner => inner.into_iter()))
+        IterEither::new(map_both!(self, inner => inner.into_iter()))
     }
 
     /// Borrows an `Either` of `Iterator`s to be an `Iterator` of `Either`s
@@ -732,7 +723,7 @@ impl<L, R> Either<L, R> {
         for<'a> &'a L: IntoIterator,
         for<'a> &'a R: IntoIterator,
     {
-        IterEither::new(map_either!(self, inner => inner.into_iter()))
+        IterEither::new(map_both!(self, inner => inner.into_iter()))
     }
 
     /// Mutably borrows an `Either` of `Iterator`s to be an `Iterator` of `Either`s
@@ -758,7 +749,7 @@ impl<L, R> Either<L, R> {
         for<'a> &'a mut L: IntoIterator,
         for<'a> &'a mut R: IntoIterator,
     {
-        IterEither::new(map_either!(self, inner => inner.into_iter()))
+        IterEither::new(map_both!(self, inner => inner.into_iter()))
     }
 
     /// Return left value or given value

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,8 @@ pub enum Either<L, R> {
 ///
 /// Syntax: `either::for_both!(` *expression* `,` *pattern* `=>` *expression* `)`
 ///
+/// Unlike [`map_both!`], this macro converges both variants to the type returned by the expression.
+///
 /// # Example
 ///
 /// ```
@@ -83,6 +85,37 @@ macro_rules! for_both {
         match $value {
             $crate::Either::Left($pattern) => $result,
             $crate::Either::Right($pattern) => $result,
+        }
+    };
+}
+
+/// Evaluate the provided expression for both [`Either::Left`] and [`Either::Right`],
+/// returning an [`Either`] with the results.
+///
+/// This macro is useful in cases where both sides of [`Either`] can be interacted with
+/// in the same way even though the don't share the same type.
+///
+/// Syntax: `either::map_both!(` *expression* `,` *pattern* `=>` *expression* `)`
+///
+/// Unlike [`for_both!`], this macro returns an [`Either`] with the results of the expressions.
+///
+/// # Example
+///
+/// ```
+/// use either::Either;
+///
+/// struct Wrapper<T>(T);
+///
+/// fn wrap(owned_or_borrowed: Either<String, &'static str>) -> Either<Wrapper<String>, Wrapper<&'static str>> {
+///    either::map_both!(owned_or_borrowed, s => Wrapper(s))
+/// }
+/// ```
+#[macro_export]
+macro_rules! map_both {
+    ($value:expr, $pattern:pat => $result:expr) => {
+        match $value {
+            $crate::Either::Left($pattern) => $crate::Either::Left($result),
+            $crate::Either::Right($pattern) => $crate::Either::Right($result),
         }
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,14 +121,15 @@ macro_rules! map_both {
 }
 
 /// Evaluate the provided expression for both [`Either::Left`] and [`Either::Right`],
-/// returning a [Result] where the [`Ok`] variant is an [`Either`] with the results.
+/// returning a `T`: [`Try`] where the [`Try::Output`] variant is an [`Either`] with outputs.
 ///
 /// This macro is useful in cases where both sides of [`Either`] can be interacted with
 /// in the same way even though the don't share the same type.
 ///
-/// `either::map_both!(` *expression* `,` *pattern* `=>` *expression* `)`
+/// `either::try_map_both!(` *expression* `,` *pattern* `=>` *expression* `)`
 ///
-/// Unlike [`map_both!`], this macro returns a [Result] where the [`Ok`] variant is an [`Either`] with the results.
+/// Unlike [`map_both!`], this macro returns a [`Try`] where the [`Try::Output`] variant is an
+/// [`Either`] with the outputs.
 ///
 /// # Examples
 ///
@@ -154,6 +155,9 @@ macro_rules! map_both {
 ///
 /// If you want to see another [`Try`](https://doc.rust-lang.org/beta/std/ops/trait.Try.html) type
 /// supported, please open an issue or a PR.
+///
+/// [`Try`]: https://doc.rust-lang.org/beta/std/ops/trait.Try.html
+/// [`Try::Output`]: https://doc.rust-lang.org/beta/std/ops/trait.Try.html#associatedtype.Output
 #[macro_export]
 macro_rules! try_map_both {
     ($value:expr, $pattern:pat => $result:expr) => {


### PR DESCRIPTION
Added an additional line to the doc of `either::for_both!`:

```
/// Unlike [`map_both!`], this macro converges both variants to the type returned by the expression.
```

Implementation of `map_both!`

```
/// Evaluate the provided expression for both [`Either::Left`] and [`Either::Right`],
/// returning an [`Either`] with the results.
///
/// This macro is useful in cases where both sides of [`Either`] can be interacted with
/// in the same way even though the don't share the same type.
///
/// Syntax: `either::map_both!(` *expression* `,` *pattern* `=>` *expression* `)`
///
/// Unlike [`for_both!`], this macro returns an [`Either`] with the results of the expressions.
///
/// # Example
///
/// ```
/// use either::Either;
///
/// struct Wrapper<T>(T);
///
/// fn wrap(owned_or_borrowed: Either<String, &'static str>) -> Either<Wrapper<String>, Wrapper<&'static str>> {
///    either::map_both!(owned_or_borrowed, s => Wrapper(s))
/// }
/// ```
#[macro_export]
macro_rules! map_both {
    ($value:expr, $pattern:pat => $result:expr) => {
        match $value {
            $crate::Either::Left($pattern) => $crate::Either::Left($result),
            $crate::Either::Right($pattern) => $crate::Either::Right($result),
        }
    };
}
```

Implementation of `try_map_both!`:

```
/// Evaluate the provided expression for both [`Either::Left`] and [`Either::Right`],
/// returning a [Result] where the [`Ok`] variant is an [`Either`] with the results.
///
/// This macro is useful in cases where both sides of [`Either`] can be interacted with
/// in the same way even though the don't share the same type.
///
/// `either::map_both!(` *expression* `,` *pattern* `=>` *expression* `)`
///
/// Unlike [`map_both!`], this macro returns a [Result] where the [`Ok`] variant is an [`Either`] with the results.
///
/// # Example
///
/// ```
/// use either::Either;
///
/// fn wrap(owned_or_borrowed: Either<String, &'static str>) -> Result<Either<String, &'static str>, ()> {
///    either::try_map_both!(owned_or_borrowed, s => Ok(s))
/// }
/// ```
#[macro_export]
macro_rules! try_map_both {
    ($value:expr, $pattern:pat => $result:expr) => {
        match $value {
            $crate::Either::Left($pattern) => match $result {
                Ok(ok) => Ok($crate::Either::Left(ok)),
                Err(err) => Err(err),
            },
            $crate::Either::Right($pattern) => match $result {
                Ok(ok) => Ok($crate::Either::Right(ok)),
                Err(err) => Err(err),
            },
        }
    };
}
```

P.S.

If you have an idea for a simple and meaningful example for `try_map_both!`, it will be very welcome!