### PR TITLE
Fix compilation on MSRV (1.37)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,14 @@ keywords = ["data-structure", "no_std"]
 categories = ["data-structures", "no-std"]
 
 [dependencies]
-serde = { version = "1.0", optional = true, features = ["derive"] }
+serde_internal = { package = "serde", version = "1.0", optional = true, features = ["derive"] }
+serde_derive = { version = "=1.0.156", optional = true }
+proc-macro2 = { version = "=1.0.65", optional = true }
 
 [features]
 default = ["use_std"]
 use_std = []
+serde = ["serde_internal", "serde_derive", "proc-macro2"]
 
 [dev-dependencies]
 serde_json = "1.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,11 @@ pub use crate::Either::{Left, Right};
 /// The `Either` type is symmetric and treats its variants the same way, without
 /// preference.
 /// (For representing success or error, use the regular `Result` enum instead.)
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_internal::Serialize, serde_internal::Deserialize)
+)]
+#[cfg_attr(feature = "serde", serde(crate = "serde_internal"))]
 #[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum Either<L, R> {
     /// A value of type `L`.

--- a/src/serde_untagged.rs
+++ b/src/serde_untagged.rs
@@ -33,10 +33,10 @@
 //! # }
 //! ```
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_internal::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(untagged)]
+#[derive(serde_internal::Serialize, serde_internal::Deserialize)]
+#[serde(crate = "serde_internal", untagged)]
 enum Either<L, R> {
     Left(L),
     Right(R),

--- a/src/serde_untagged.rs
+++ b/src/serde_untagged.rs
@@ -7,11 +7,13 @@
 //!
 //! ```rust
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # extern crate serde_internal as serde;
 //! use either::Either;
 //! use std::collections::HashMap;
 //!
 //! #[derive(serde::Serialize, serde::Deserialize, Debug)]
 //! #[serde(transparent)]
+//! # #[serde(crate = "serde_internal")]
 //! struct IntOrString {
 //!     #[serde(with = "either::serde_untagged")]
 //!     inner: Either<Vec<String>, HashMap<String, i32>>

--- a/src/serde_untagged_optional.rs
+++ b/src/serde_untagged_optional.rs
@@ -33,10 +33,10 @@
 //! # }
 //! ```
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_internal::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(crate = "serde_internal", untagged)]
 enum Either<L, R> {
     Left(L),
     Right(R),

--- a/src/serde_untagged_optional.rs
+++ b/src/serde_untagged_optional.rs
@@ -7,11 +7,13 @@
 //!
 //! ```rust
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # extern crate serde_internal as serde;
 //! use either::Either;
 //! use std::collections::HashMap;
 //!
 //! #[derive(serde::Serialize, serde::Deserialize, Debug)]
 //! #[serde(transparent)]
+//! # #[serde(crate = "serde_internal")]
 //! struct IntOrString {
 //!     #[serde(with = "either::serde_untagged_optional")]
 //!     inner: Option<Either<Vec<String>, HashMap<String, i32>>>


### PR DESCRIPTION
Latest versions of `serde_derive`, `syn` and `proc_macro2` have all raised the MSRV to be incompatible with `either`'s MSRV, which is at 1.37.
This fixes compilation on MSRV (i.e. `cargo +1.37 build --all-features`)

Personally, I think raising MSRV is a better option. 1.37 was released 5.5 years ago, so it's quite old by now, and this fix will cause downstream users to get `syn` version 1.x in their dep tree, even though they might be already be using 2.x (and maybe other duplicated crates, or just older versions of non-duplicated crates).