### PR TITLE
fix: no-std with serde feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
 
       - name: Build (no_std)
-        run: cargo build --no-default-features
+        run: cargo build --no-default-features --features "${{ matrix.features }}"
 
       - name: Build
         run: cargo build --features "${{ matrix.features }}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["data-structure", "no_std"]
 categories = ["data-structures", "no-std"]
 
 [dependencies]
-serde = { version = "1.0", optional = true, default-features = false, features = ["alloc", "derive"] }
+serde = { version = "1.0.95", optional = true, default-features = false, features = ["alloc", "derive"] }
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ categories = ["data-structures", "no-std"]
 serde = { version = "1.0", optional = true, default-features = false, features = ["alloc", "derive"] }
 
 [features]
-default = ["use_std"]
-use_std = []
-std = ["use_std"]
+default = ["std"]
+std = []
+use_std = ["std"] # deprecated alias
 
 [dev-dependencies]
 serde_json = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,12 @@ keywords = ["data-structure", "no_std"]
 categories = ["data-structures", "no-std"]
 
 [dependencies]
-serde = { version = "1.0", optional = true, features = ["derive"] }
+serde = { version = "1.0", optional = true, default-features = false, features = ["alloc", "derive"] }
 
 [features]
 default = ["use_std"]
 use_std = []
+std = ["use_std"]
 
 [dev-dependencies]
 serde_json = "1.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1280,17 +1280,17 @@ impl_specific_ref_and_mut!(str,);
 impl_specific_ref_and_mut!(
     ::std::path::Path,
     cfg(feature = "std"),
-    doc = "Requires crate feature `use_std`."
+    doc = "Requires crate feature `std`."
 );
 impl_specific_ref_and_mut!(
     ::std::ffi::OsStr,
     cfg(feature = "std"),
-    doc = "Requires crate feature `use_std`."
+    doc = "Requires crate feature `std`."
 );
 impl_specific_ref_and_mut!(
     ::std::ffi::CStr,
     cfg(feature = "std"),
-    doc = "Requires crate feature `use_std`."
+    doc = "Requires crate feature `std`."
 );
 
 impl<L, R, Target> AsRef<[Target]> for Either<L, R>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! **Crate features:**
 //!
-//! * `"use_std"`
+//! * `"std"`
 //!   Enabled by default. Disable to make the library `#![no_std]`.
 //!
 //! * `"serde"`
@@ -15,7 +15,7 @@
 #![doc(html_root_url = "https://docs.rs/either/1/")]
 #![no_std]
 
-#[cfg(any(test, feature = "use_std"))]
+#[cfg(any(test, feature = "std"))]
 extern crate std;
 
 #[cfg(feature = "serde")]
@@ -31,9 +31,9 @@ use core::ops::Deref;
 use core::ops::DerefMut;
 use core::pin::Pin;
 
-#[cfg(any(test, feature = "use_std"))]
+#[cfg(any(test, feature = "std"))]
 use std::error::Error;
-#[cfg(any(test, feature = "use_std"))]
+#[cfg(any(test, feature = "std"))]
 use std::io::{self, BufRead, Read, Seek, SeekFrom, Write};
 
 pub use crate::Either::{Left, Right};
@@ -1154,10 +1154,10 @@ where
     }
 }
 
-#[cfg(any(test, feature = "use_std"))]
+#[cfg(any(test, feature = "std"))]
 /// `Either<L, R>` implements `Read` if both `L` and `R` do.
 ///
-/// Requires crate feature `"use_std"`
+/// Requires crate feature `"std"`
 impl<L, R> Read for Either<L, R>
 where
     L: Read,
@@ -1180,10 +1180,10 @@ where
     }
 }
 
-#[cfg(any(test, feature = "use_std"))]
+#[cfg(any(test, feature = "std"))]
 /// `Either<L, R>` implements `Seek` if both `L` and `R` do.
 ///
-/// Requires crate feature `"use_std"`
+/// Requires crate feature `"std"`
 impl<L, R> Seek for Either<L, R>
 where
     L: Seek,
@@ -1194,8 +1194,8 @@ where
     }
 }
 
-#[cfg(any(test, feature = "use_std"))]
-/// Requires crate feature `"use_std"`
+#[cfg(any(test, feature = "std"))]
+/// Requires crate feature `"std"`
 impl<L, R> BufRead for Either<L, R>
 where
     L: BufRead,
@@ -1218,10 +1218,10 @@ where
     }
 }
 
-#[cfg(any(test, feature = "use_std"))]
+#[cfg(any(test, feature = "std"))]
 /// `Either<L, R>` implements `Write` if both `L` and `R` do.
 ///
-/// Requires crate feature `"use_std"`
+/// Requires crate feature `"std"`
 impl<L, R> Write for Either<L, R>
 where
     L: Write,
@@ -1279,17 +1279,17 @@ macro_rules! impl_specific_ref_and_mut {
 impl_specific_ref_and_mut!(str,);
 impl_specific_ref_and_mut!(
     ::std::path::Path,
-    cfg(feature = "use_std"),
+    cfg(feature = "std"),
     doc = "Requires crate feature `use_std`."
 );
 impl_specific_ref_and_mut!(
     ::std::ffi::OsStr,
-    cfg(feature = "use_std"),
+    cfg(feature = "std"),
     doc = "Requires crate feature `use_std`."
 );
 impl_specific_ref_and_mut!(
     ::std::ffi::CStr,
-    cfg(feature = "use_std"),
+    cfg(feature = "std"),
     doc = "Requires crate feature `use_std`."
 );
 
@@ -1345,10 +1345,10 @@ where
     }
 }
 
-#[cfg(any(test, feature = "use_std"))]
+#[cfg(any(test, feature = "std"))]
 /// `Either` implements `Error` if *both* `L` and `R` implement it.
 ///
-/// Requires crate feature `"use_std"`
+/// Requires crate feature `"std"`
 impl<L, R> Error for Either<L, R>
 where
     L: Error,
@@ -1553,7 +1553,7 @@ fn _unsized_ref_propagation() {
 }
 
 // This "unused" method is here to ensure that compilation doesn't fail on given types.
-#[cfg(feature = "use_std")]
+#[cfg(feature = "std")]
 fn _unsized_std_propagation() {
     check_t!(::std::path::Path);
     check_t!(::std::ffi::OsStr);


### PR DESCRIPTION
Closes https://github.com/rayon-rs/either/issues/26

Adds a more common `std` alias for `use_std` feature and disables default features for serde crate thus fixing no-std support for compilation with `serde` enabled