### PR TITLE
Implement `TrustedLen` and some unstable methods for iterators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde = { version = "1.0.95", optional = true, default-features = false, feature
 default = ["std"]
 std = []
 use_std = ["std"] # deprecated alias
+nightly = []
 
 [dev-dependencies]
 serde_json = "1.0.0"

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -130,6 +130,21 @@ where
     {
         for_both!(self, inner => inner.position(predicate))
     }
+
+    #[cfg(feature = "nightly")]
+    fn advance_by(&mut self, n: usize) -> Result<(), core::num::NonZeroUsize> {
+        for_both!(self, inner => inner.advance_by(n))
+    }
+
+    #[cfg(feature = "nightly")]
+    fn try_fold<B, F, T>(&mut self, init: B, f: F) -> T
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> T,
+        T: core::ops::Try<Output = B>,
+    {
+        for_both!(self, inner => inner.try_fold(init, f))
+    }
 }
 
 impl<L, R> DoubleEndedIterator for Either<L, R>
@@ -158,6 +173,21 @@ where
     {
         for_both!(self, inner => inner.rfind(predicate))
     }
+
+    #[cfg(feature = "nightly")]
+    fn advance_back_by(&mut self, n: usize) -> Result<(), core::num::NonZeroUsize> {
+        for_both!(self, ref mut inner => inner.advance_back_by(n))
+    }
+
+    #[cfg(feature = "nightly")]
+    fn try_rfold<B, F, T>(&mut self, init: B, f: F) -> T
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> T,
+        T: core::ops::Try<Output = B>,
+    {
+        for_both!(self, inner => inner.try_fold(init, f))
+    }
 }
 
 impl<L, R> ExactSizeIterator for Either<L, R>
@@ -168,6 +198,14 @@ where
     fn len(&self) -> usize {
         for_both!(self, inner => inner.len())
     }
+}
+
+#[cfg(feature = "nightly")]
+unsafe impl<L, R> iter::TrustedLen for Either<L, R>
+where
+    L: iter::TrustedLen,
+    R: iter::TrustedLen<Item = L::Item>,
+{
 }
 
 impl<L, R> iter::FusedIterator for Either<L, R>
@@ -267,6 +305,21 @@ where
     {
         wrap_either!(&mut self.inner => .position(predicate))
     }
+
+    #[cfg(feature = "nightly")]
+    fn advance_by(&mut self, n: usize) -> Result<(), core::num::NonZeroUsize> {
+        for_both!(self.inner, ref mut inner => inner.advance_by(n))
+    }
+
+    #[cfg(feature = "nightly")]
+    fn try_fold<B, F, T>(&mut self, init: B, f: F) -> T
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> T,
+        T: core::ops::Try<Output = B>,
+    {
+        wrap_either!(&mut self.inner => .try_fold(init, f))
+    }
 }
 
 impl<L, R> DoubleEndedIterator for IterEither<L, R>
@@ -295,6 +348,21 @@ where
     {
         wrap_either!(&mut self.inner => .rfind(predicate))
     }
+
+    #[cfg(feature = "nightly")]
+    fn advance_back_by(&mut self, n: usize) -> Result<(), core::num::NonZeroUsize> {
+        for_both!(self.inner, ref mut inner => inner.advance_back_by(n))
+    }
+
+    #[cfg(feature = "nightly")]
+    fn try_rfold<B, F, T>(&mut self, init: B, f: F) -> T
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> T,
+        T: core::ops::Try<Output = B>,
+    {
+        wrap_either!(&mut self.inner => .try_rfold(init, f))
+    }
 }
 
 impl<L, R> ExactSizeIterator for IterEither<L, R>
@@ -305,6 +373,14 @@ where
     fn len(&self) -> usize {
         for_both!(self.inner, ref inner => inner.len())
     }
+}
+
+#[cfg(feature = "nightly")]
+unsafe impl<L, R> iter::TrustedLen for IterEither<L, R>
+where
+    L: iter::TrustedLen,
+    R: iter::TrustedLen,
+{
 }
 
 impl<L, R> iter::FusedIterator for IterEither<L, R>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,15 @@
 //! * `"serde"`
 //!   Disabled by default. Enable to `#[derive(Serialize, Deserialize)]` for `Either`
 //!
+//! * `"nightly"`
+//!   Disabled by default. Enable to use nightly-only features for `Iterator` implementations.
+//!   This feature should be considered unstable and may break at any time.
+//!
 
+#![cfg_attr(
+    feature = "nightly",
+    feature(iter_advance_by, try_trait_v2, trusted_len)
+)]
 #![doc(html_root_url = "https://docs.rs/either/1/")]
 #![no_std]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1066,10 +1066,7 @@ impl<T> Either<T, T> {
     where
         F: FnOnce(T) -> M,
     {
-        match self {
-            Left(l) => Left(f(l)),
-            Right(r) => Right(f(r)),
-        }
+        map_either!(self, t => f(t))
     }
 }
 

--- a/src/serde_untagged.rs
+++ b/src/serde_untagged.rs
@@ -1,9 +1,9 @@
-//! Untagged serialization/deserialization support for Either<L, R>.
+//! Untagged serialization/deserialization support for `Either<L, R>`.
 //!
 //! `Either` uses default, externally-tagged representation.
 //! However, sometimes it is useful to support several alternative types.
-//! For example, we may have a field which is generally Map<String, i32>
-//! but in typical cases Vec<String> would suffice, too.
+//! For example, we may have a field which is generally a `HashMap<String, i32>`
+//! but in typical cases `Vec<String>` would suffice, too.
 //!
 //! ```rust
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/serde_untagged_optional.rs
+++ b/src/serde_untagged_optional.rs
@@ -1,9 +1,9 @@
-//! Untagged serialization/deserialization support for Option<Either<L, R>>.
+//! Untagged serialization/deserialization support for `Option<Either<L, R>>`.
 //!
 //! `Either` uses default, externally-tagged representation.
 //! However, sometimes it is useful to support several alternative types.
-//! For example, we may have a field which is generally Map<String, i32>
-//! but in typical cases Vec<String> would suffice, too.
+//! For example, we may have a field which is generally a `HashMap<String, i32>`
+//! but in typical cases `Vec<String>` would suffice, too.
 //!
 //! ```rust
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
Hope this is acceptable :)

This impls a few things for `IterEither` and `Either`:
* The `TrustedLen` trait (if both underlying iterators are `TrustedLen`)
* `advance_by` (and `advance_back_by` for DEIs)
* `try_fold` (and `try_rfold` for DEIs)

I think this might improve perf in certain use-cases in rustdoc, and might be generally useful for folks using the nightly toolchain compiler. I think having this addition definitely can't heart, and it's gated under a feature flag that hopefully makes it very clear that this might break with every nightly version of rustc.

First two commits are unrelated drive-by cleanups.