### PR TITLE
Added coverage CI and badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,23 @@ jobs:
 
       - name: Clippy
         run: cargo clippy  # -- -D warnings
+  
+  coverage:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Install tarpaulin
+        run: cargo install cargo-tarpaulin
+      - name: Generate coverage
+        run: cargo tarpaulin --engine=llvm --out xml --workspace --run-types AllTargets --run-types Doctests --all-features
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
   # One job that "summarizes" the success state of this pipeline. This can then be added to branch
   # protection, rather than having to add each job separately.

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+cobertura.xml

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,14 @@ Please read the `API documentation here`__
 
 __ https://docs.rs/either/
 
-|build_status|_ |crates|_
+|build_status|_ |crates|_ |codecov|_
 
 .. |build_status| image:: https://github.com/rayon-rs/either/workflows/CI/badge.svg?branch=main
 .. _build_status: https://github.com/rayon-rs/either/actions
 
 .. |crates| image:: https://img.shields.io/crates/v/either.svg
 .. _crates: https://crates.io/crates/either
+.. |codecov| image:: https://codecov.io/gh/rayon-rs/either/branch/main/graph/badge.svg
 
 How to use with cargo::
 


### PR DESCRIPTION
Closes issue #133 

I may make more PRs in the future to extend the coverage, which at this time is at around 50% according to the following tarpaulin command:

```bash
cargo tarpaulin --engine=llvm --out xml --workspace --run-types AllTargets --run-types Doctests --all-features
```

Producing the following output:

```bash
|| Tested/Total Lines:
|| src/into_either.rs: 7/7 +0.00%
|| src/iterator.rs: 15/79 +0.00%
|| src/lib.rs: 143/238 +0.00%
|| src/serde_untagged.rs: 7/10 +0.00%
|| src/serde_untagged_optional.rs: 7/12 +0.00%
|| 
51.73% coverage, 179/346 lines covered, +0.00% change in coverage
```

Best,
Luca