### PR TITLE
Add implementations for all missing `std::fmt` traits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,11 @@ jobs:
         env:
           CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
         # Note that this uses the runner's pre-installed stable cargo
-        run: cargo generate-lockfile
+        # Also, the resolver is still too greedy, pulling in too-new serde_derive:
+        # https://github.com/serde-rs/serde/issues/3088
+        run: |
+          cargo generate-lockfile
+          cargo update -p serde --precise 1.0.228
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 edition = "2021"
 rust-version = "1.63.0"
 

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,10 @@ How to use with cargo::
 Recent Changes
 --------------
 
+- 1.17.0
+
+  - Add implementations for all ``std::fmt`` traits, by @msrd0 (#141)
+
 - 1.16.0
 
   - Add many new methods dealing with each side, by @A4-Tacks:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1644,6 +1644,26 @@ where
     }
 }
 
+impl<L, R> fmt::LowerHex for Either<L, R>
+where
+    L: fmt::LowerHex,
+    R: fmt::LowerHex,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for_both!(self, inner => inner.fmt(f))
+    }
+}
+
+impl<L, R> fmt::UpperHex for Either<L, R>
+where
+    L: fmt::UpperHex,
+    R: fmt::UpperHex,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for_both!(self, inner => inner.fmt(f))
+    }
+}
+
 impl<L, R> fmt::Write for Either<L, R>
 where
     L: fmt::Write,
@@ -1698,6 +1718,16 @@ fn deref() {
     fn is_str(_: &str) {}
     let value: Either<String, &str> = Left(String::from("test"));
     is_str(&value);
+}
+
+#[test]
+fn fmt_traits() {
+    use std::format;
+
+    let value: Either<u32, i32> = Left(0xC0DE);
+    assert_eq!("49374", format!("{value}"));
+    assert_eq!("c0de", format!("{value:x}"));
+    assert_eq!("C0DE", format!("{value:X}"));
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1634,35 +1634,23 @@ where
     }
 }
 
-impl<L, R> fmt::Display for Either<L, R>
-where
-    L: fmt::Display,
-    R: fmt::Display,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for_both!(self, inner => inner.fmt(f))
+macro_rules! impl_fmt_traits {
+    ($($trait:ident),*) => {
+        $(
+            impl <L, R> fmt::$trait for Either<L, R>
+            where
+                L: fmt::$trait,
+                R: fmt::$trait,
+            {
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    for_both!(self, inner => fmt::$trait::fmt(inner, f))
+                }
+            }
+        )*
     }
 }
 
-impl<L, R> fmt::LowerHex for Either<L, R>
-where
-    L: fmt::LowerHex,
-    R: fmt::LowerHex,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for_both!(self, inner => inner.fmt(f))
-    }
-}
-
-impl<L, R> fmt::UpperHex for Either<L, R>
-where
-    L: fmt::UpperHex,
-    R: fmt::UpperHex,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for_both!(self, inner => inner.fmt(f))
-    }
-}
+impl_fmt_traits!(Binary, Display, LowerExp, LowerHex, Octal, Pointer, UpperExp, UpperHex);
 
 impl<L, R> fmt::Write for Either<L, R>
 where
@@ -1725,8 +1713,19 @@ fn fmt_traits() {
     use std::format;
 
     let value: Either<u32, i32> = Left(0xC0DE);
+    // fmt::Binary
+    assert_eq!("1100000011011110", format!("{value:b}"));
+    // fmt::Display
     assert_eq!("49374", format!("{value}"));
+    // fmt::LowerExp
+    assert_eq!("4.9374e4", format!("{value:e}"));
+    // fmt::LowerHex
     assert_eq!("c0de", format!("{value:x}"));
+    // fmt::Octal
+    assert_eq!("140336", format!("{value:o}"));
+    // fmt::UpperExp
+    assert_eq!("4.9374E4", format!("{value:E}"));
+    // fmt::UpperHex
     assert_eq!("C0DE", format!("{value:X}"));
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1727,6 +1727,10 @@ fn fmt_traits() {
     assert_eq!("4.9374E4", format!("{value:E}"));
     // fmt::UpperHex
     assert_eq!("C0DE", format!("{value:X}"));
+
+    // fmt::Pointer
+    let pointer: Either<*const u32, &mut i32> = Left(std::ptr::null());
+    assert_eq!("0x0", format!("{pointer:p}"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #140 