### PR TITLE
Add trait impls akin to `partition_map`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 edition = "2021"
 rust-version = "1.63.0"
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,8 @@
+- 1.18.0 - 2026-08-20
+  - Add trait impls akin to `Itertools::partition_map`, by @cuviper (#144)
+    - `Extend<Either<L, R>> for (A, B)`
+    - `FromIterator<Either<L, R>> for (A, B)`
+
 - 1.17.0 - 2026-07-24
   - Add implementations for all `std::fmt` traits, by @msrd0 (#141)
 

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -39,6 +39,48 @@ where
     }
 }
 
+impl<A, B, L, R> Extend<Either<L, R>> for (A, B)
+where
+    A: Extend<L>,
+    B: Extend<R>,
+{
+    fn extend<T>(&mut self, iter: T)
+    where
+        T: IntoIterator<Item = Either<L, R>>,
+    {
+        iter.into_iter().for_each(move |item| match item {
+            // TODO: use `Extend::extend_one` <https://github.com/rust-lang/rust/issues/72631>
+            Left(item) => self.0.extend(iter::once(item)),
+            Right(item) => self.1.extend(iter::once(item)),
+        });
+    }
+}
+
+/// Collects `Left` and `Right` items into separate collections
+///
+/// ```
+/// use either::Either::*;
+/// let (threes, other): (Vec<i32>, Vec<i32>) = (1..10)
+///     .map(|i| if i % 3 == 0 { Left(i) } else { Right(i) })
+///     .collect();
+/// assert_eq!(threes, [3, 6, 9]);
+/// assert_eq!(other, [1, 2, 4, 5, 7, 8]);
+/// ```
+impl<A, B, L, R> FromIterator<Either<L, R>> for (A, B)
+where
+    A: Default + Extend<L>,
+    B: Default + Extend<R>,
+{
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = Either<L, R>>,
+    {
+        let mut pair = (A::default(), B::default());
+        pair.extend(iter);
+        pair
+    }
+}
+
 /// `Either<L, R>` is an iterator if both `L` and `R` are iterators.
 impl<L, R> Iterator for Either<L, R>
 where


### PR DESCRIPTION
[`Itertools::partition_map`](https://docs.rs/itertools/latest/itertools/trait.Itertools.html#method.partition_map) collects a mapped `Either` to a left or right container depending on the variant. We can enable the same thing with the standard `Extend` and `FromIterator`, assuming you `map` it independently, and then plain `Iterator::collect` will work too.

```rust
impl<A, B, L, R> Extend<Either<L, R>> for (A, B)
where
    A: Extend<L>,
    B: Extend<R>,
{...}

impl<A, B, L, R> FromIterator<Either<L, R>> for (A, B)
where
    A: Default + Extend<L>,
    B: Default + Extend<R>,
{...}
```

Note that rayon already does this for its own `ParallelExtend` and `FromParallelIterator` as well.

Closes #143